### PR TITLE
Start to move the prefix out of the Branch, replacing prior word and prefix vec

### DIFF
--- a/src/stored.rs
+++ b/src/stored.rs
@@ -21,7 +21,10 @@ pub trait Store<V> {
         hash_idx: Idx,
     ) -> Result<NodeHash, Self::Error>;
 
-    fn get_node(&self, hash_idx: Idx) -> Result<Node<&Branch<Idx>, &Leaf<V>>, Self::Error>;
+    fn get_node<'s>(
+        &'s self,
+        hash_idx: Idx,
+    ) -> Result<Node<&'s Branch<'s, Idx>, &'s Leaf<V>>, Self::Error>;
 }
 
 impl<V, S: Store<V>> Store<V> for &S {

--- a/src/stored/merkle.rs
+++ b/src/stored/merkle.rs
@@ -5,7 +5,7 @@ use bumpalo::Bump;
 use ouroboros::self_referencing;
 
 use crate::{
-    transaction::nodes::{NodeRef, TrieRoot},
+    transaction::nodes::{NodeRef, PrefixesBuffer, TrieRoot},
     Branch, Leaf, PortableHash, PortableHasher, TrieError,
 };
 
@@ -20,12 +20,14 @@ type Result<T, E = TrieError> = core::result::Result<T, E>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Snapshot<V> {
     /// The last branch is the root of the trie if it exists.
-    branches: Box<[Branch<Idx>]>,
+    branches: Box<[Branch<'static, Idx>]>,
     /// A Snapshot containing only
     leaves: Box<[Leaf<V>]>,
 
     // we only store the hashes of the nodes that have not been visited.
     unvisited_nodes: Box<[NodeHash]>,
+
+    prefixies_buffer: PrefixesBuffer,
 }
 
 impl<V: PortableHash> Snapshot<V> {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -22,7 +22,6 @@ use self::nodes::{
 pub struct Transaction<S, V> {
     pub data_store: S,
     current_root: TrieRoot<NodeRef<V>>,
-    prefixes_buffer: PrefixesBuffer,
 }
 
 impl<Db: DatabaseSet<V>, V: Clone + PortableHash> Transaction<SnapshotBuilder<Db, V>, V> {
@@ -44,7 +43,6 @@ impl<Db: DatabaseSet<V>, V: Clone + PortableHash> Transaction<SnapshotBuilder<Db
                     left,
                     right,
                     mask: branch.mask,
-                    prior_word: branch.prior_word,
                     prefix: branch.prefix.clone(),
                 };
 
@@ -397,6 +395,7 @@ impl<S: Store<V>, V> Transaction<S, V> {
                                 mask: new_branch.mask,
                                 prior_word: new_branch.prior_word,
                                 prefix: new_branch.prefix.clone(),
+                                prefix,
                             }));
 
                             continue;
@@ -549,6 +548,7 @@ impl<Db, V: PortableHash + Clone> Transaction<SnapshotBuilder<Db, V>, V> {
         Transaction {
             current_root: builder.trie_root(),
             data_store: builder,
+            prefixes_buffer: builder.prefixes_buffer,
         }
     }
 }
@@ -582,6 +582,7 @@ impl<V: PortableHash + Clone> Transaction<Snapshot<V>, V> {
         Ok(Transaction {
             current_root: snapshot.trie_root()?,
             data_store: snapshot,
+            prefixes_buffer: snapshot.prefixes_buffer,
         })
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,12 +15,14 @@ use crate::{
 };
 
 use self::nodes::{
-    Branch, KeyPosition, KeyPositionAdjacent, Leaf, Node, NodeRef, StoredLeafRef, TrieRoot,
+    Branch, KeyPosition, KeyPositionAdjacent, Leaf, Node, NodeRef, PrefixesBuffer, StoredLeafRef,
+    TrieRoot,
 };
 
 pub struct Transaction<S, V> {
     pub data_store: S,
     current_root: TrieRoot<NodeRef<V>>,
+    prefixes_buffer: PrefixesBuffer,
 }
 
 impl<Db: DatabaseSet<V>, V: Clone + PortableHash> Transaction<SnapshotBuilder<Db, V>, V> {


### PR DESCRIPTION
This will allow bytemuck cast to be used to serialize Snapshots. This was a goal of the original design, but was not possible due to switch to prefixes from extension nodes.

Deserialization is makes up about 30% of cycles in our risc0 proofs, second only to hashing.